### PR TITLE
Make machine constructible from state

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -66,6 +66,14 @@ impl Machine {
 	pub fn position(&self) -> &Result<usize, ExitReason> {
 		&self.position
 	}
+	/// Return a reference of the return range.
+	pub fn return_range(&self) -> &Range<U256> {
+		&self.return_range
+	}
+	/// Return a reference of the valids.
+	pub fn return_valids(&self) -> &Valids {
+		&self.valids
+	}
 
 	/// Create a new machine with given code and data.
 	pub fn new(

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -71,8 +71,16 @@ impl Machine {
 		&self.return_range
 	}
 	/// Return a reference of the valids.
-	pub fn return_valids(&self) -> &Valids {
+	pub fn valids(&self) -> &Valids {
 		&self.valids
+	}
+	/// Return a reference of the return range.
+	pub fn code(&mut self) -> Vec<u8> {
+		self.code.to_vec()
+	}
+	/// Return a reference of the valids.
+	pub fn data(&self) -> Vec<u8> {
+		self.data.to_vec()
 	}
 
 	/// Create a new machine with given code and data.

--- a/runtime/src/eval/system.rs
+++ b/runtime/src/eval/system.rs
@@ -406,6 +406,8 @@ pub fn call<H: Handler>(runtime: &mut Runtime, scheme: CallScheme, handler: &mut
 		gas,
 		scheme == CallScheme::StaticCall,
 		context,
+		out_offset,
+		out_len,
 	) {
 		Capture::Exit((reason, return_data)) => {
 			runtime.return_data_buffer = return_data;

--- a/runtime/src/handler.rs
+++ b/runtime/src/handler.rs
@@ -101,6 +101,8 @@ pub trait Handler {
 		target_gas: Option<u64>,
 		is_static: bool,
 		context: Context,
+		memory_offset: U256,
+		offset_len: U256,
 	) -> Capture<(ExitReason, Vec<u8>), Self::CallInterrupt>;
 	/// Feed in call feedback.
 	fn call_feedback(&mut self, _feedback: Self::CallFeedback) -> Result<(), ExitError> {

--- a/runtime/src/interrupt.rs
+++ b/runtime/src/interrupt.rs
@@ -1,4 +1,4 @@
-use crate::{ExitFatal, Handler, Runtime};
+use crate::{Handler, Runtime};
 
 /// Interrupt resolution.
 pub enum Resolve<'a, 'config, H: Handler> {
@@ -9,6 +9,7 @@ pub enum Resolve<'a, 'config, H: Handler> {
 }
 
 /// Create interrupt resolution.
+#[allow(dead_code)]
 pub struct ResolveCreate<'a, 'config> {
 	runtime: &'a mut Runtime<'config>,
 }
@@ -20,6 +21,7 @@ impl<'a, 'config> ResolveCreate<'a, 'config> {
 }
 
 /// Call interrupt resolution.
+#[allow(dead_code)]
 pub struct ResolveCall<'a, 'config> {
 	runtime: &'a mut Runtime<'config>,
 }

--- a/runtime/src/interrupt.rs
+++ b/runtime/src/interrupt.rs
@@ -19,15 +19,6 @@ impl<'a, 'config> ResolveCreate<'a, 'config> {
 	}
 }
 
-impl<'a, 'config> Drop for ResolveCreate<'a, 'config> {
-	fn drop(&mut self) {
-		self.runtime.status = Err(ExitFatal::UnhandledInterrupt.into());
-		self.runtime
-			.machine
-			.exit(ExitFatal::UnhandledInterrupt.into());
-	}
-}
-
 /// Call interrupt resolution.
 pub struct ResolveCall<'a, 'config> {
 	runtime: &'a mut Runtime<'config>,
@@ -36,14 +27,5 @@ pub struct ResolveCall<'a, 'config> {
 impl<'a, 'config> ResolveCall<'a, 'config> {
 	pub(crate) fn new(runtime: &'a mut Runtime<'config>) -> Self {
 		Self { runtime }
-	}
-}
-
-impl<'a, 'config> Drop for ResolveCall<'a, 'config> {
-	fn drop(&mut self) {
-		self.runtime.status = Err(ExitFatal::UnhandledInterrupt.into());
-		self.runtime
-			.machine
-			.exit(ExitFatal::UnhandledInterrupt.into());
 	}
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -151,6 +151,11 @@ impl<'config> Runtime<'config> {
 		&mut self.machine
 	}
 
+	/// Get a reference to the return buffer
+	pub fn return_data_buffer(&mut self) -> &mut Vec<u8> {
+		&mut self.return_data_buffer
+	}
+
 	/// Get a reference to the execution context.
 	pub fn context(&self) -> &Context {
 		&self.context

--- a/src/executor/stack/executor.rs
+++ b/src/executor/stack/executor.rs
@@ -1220,12 +1220,12 @@ impl<'config, 'precompiles, S: StackState<'config>, P: PrecompileSet> Handler
 }
 
 pub struct StackExecutorHandle<'inner, 'config, 'precompiles, S, P> {
-	executor: &'inner mut StackExecutor<'config, 'precompiles, S, P>,
-	code_address: H160,
-	input: &'inner [u8],
-	gas_limit: Option<u64>,
-	context: &'inner Context,
-	is_static: bool,
+	pub executor: &'inner mut StackExecutor<'config, 'precompiles, S, P>,
+	pub code_address: H160,
+	pub input: &'inner [u8],
+	pub gas_limit: Option<u64>,
+	pub context: &'inner Context,
+	pub is_static: bool,
 }
 
 impl<'inner, 'config, 'precompiles, S: StackState<'config>, P: PrecompileSet> PrecompileHandle

--- a/src/executor/stack/executor.rs
+++ b/src/executor/stack/executor.rs
@@ -1134,6 +1134,8 @@ impl<'config, 'precompiles, S: StackState<'config>, P: PrecompileSet> Handler
 		target_gas: Option<u64>,
 		is_static: bool,
 		context: Context,
+		_memory_offset: U256,
+		_offset_len: U256,
 	) -> Capture<(ExitReason, Vec<u8>), Self::CallInterrupt> {
 		self.call_inner(
 			code_address,
@@ -1283,6 +1285,8 @@ impl<'inner, 'config, 'precompiles, S: StackState<'config>, P: PrecompileSet> Pr
 			gas_limit,
 			is_static,
 			context.clone(),
+			U256::default(),
+			U256::default(),
 		) {
 			Capture::Exit((s, v)) => (s, v),
 			Capture::Trap(_) => unreachable!("Trap is infaillible since StackExecutor is sync"),

--- a/src/executor/stack/executor.rs
+++ b/src/executor/stack/executor.rs
@@ -1158,6 +1158,8 @@ impl<'config, 'precompiles, S: StackState<'config>, P: PrecompileSet> Handler
 		target_gas: Option<u64>,
 		is_static: bool,
 		context: Context,
+		_memory_offset: U256,
+		_offset_len: U256,
 	) -> Capture<(ExitReason, Vec<u8>), Self::CallInterrupt> {
 		let capture = self.call_inner(
 			code_address,

--- a/src/executor/stack/executor.rs
+++ b/src/executor/stack/executor.rs
@@ -1219,7 +1219,7 @@ impl<'config, 'precompiles, S: StackState<'config>, P: PrecompileSet> Handler
 	}
 }
 
-struct StackExecutorHandle<'inner, 'config, 'precompiles, S, P> {
+pub struct StackExecutorHandle<'inner, 'config, 'precompiles, S, P> {
 	executor: &'inner mut StackExecutor<'config, 'precompiles, S, P>,
 	code_address: H160,
 	input: &'inner [u8],

--- a/src/executor/stack/memory.rs
+++ b/src/executor/stack/memory.rs
@@ -38,12 +38,41 @@ impl<'config> MemoryStackSubstate<'config> {
 		}
 	}
 
+	pub fn from_state(
+		metadata: StackSubstateMetadata<'config>,
+		logs: Vec<Log>,
+		accounts: BTreeMap<H160, MemoryStackAccount>,
+		storages: BTreeMap<(H160, H256), H256>,
+		deletes: BTreeSet<H160>,
+	) -> Self {
+		Self {
+			metadata,
+			parent: None,
+			logs,
+			accounts,
+			storages,
+			deletes,
+		}
+	}
+
 	pub fn logs(&self) -> &[Log] {
 		&self.logs
 	}
 
 	pub fn logs_mut(&mut self) -> &mut Vec<Log> {
 		&mut self.logs
+	}
+
+	pub fn accounts(&self) -> &BTreeMap<H160, MemoryStackAccount> {
+		&self.accounts
+	}
+
+	pub fn storages(&self) -> &BTreeMap<(H160, H256), H256> {
+		&self.storages
+	}
+
+	pub fn deletes(&self) -> &BTreeSet<H160> {
+		&self.deletes
 	}
 
 	pub fn metadata(&self) -> &StackSubstateMetadata<'config> {

--- a/src/executor/stack/memory.rs
+++ b/src/executor/stack/memory.rs
@@ -584,6 +584,14 @@ impl<'backend, 'config, B: Backend> MemoryStackState<'backend, 'config, B> {
 		}
 	}
 
+	pub fn new_with_substate(substate: MemoryStackSubstate<'config>, backend: &'backend B) -> Self {
+		Self { backend, substate }
+	}
+
+	pub fn substate(&self) -> &MemoryStackSubstate {
+		&self.substate
+	}
+
 	/// Returns a mutable reference to an account given its address
 	pub fn account_mut(&mut self, address: H160) -> &mut MemoryStackAccount {
 		self.substate.account_mut(address, self.backend)

--- a/src/executor/stack/mod.rs
+++ b/src/executor/stack/mod.rs
@@ -7,7 +7,7 @@ mod memory;
 
 pub use self::executor::{
 	Accessed, PrecompileFailure, PrecompileFn, PrecompileHandle, PrecompileOutput, PrecompileSet,
-	StackExecutor, StackExitKind, StackState, StackSubstateMetadata,
+	StackExecutor, StackExecutorHandle, StackExitKind, StackState, StackSubstateMetadata,
 };
 
 pub use self::memory::{MemoryStackAccount, MemoryStackState, MemoryStackSubstate};

--- a/src/executor/stack/mod.rs
+++ b/src/executor/stack/mod.rs
@@ -6,8 +6,9 @@ mod executor;
 mod memory;
 
 pub use self::executor::{
-	Accessed, PrecompileFailure, PrecompileFn, PrecompileHandle, PrecompileOutput, PrecompileSet,
-	StackExecutor, StackExecutorHandle, StackExitKind, StackState, StackSubstateMetadata,
+	Accessed, PrecompileFailure, PrecompileFn, PrecompileHandle, PrecompileOutput,
+	PrecompileOutputType, PrecompileSet, StackExecutor, StackExecutorHandle, StackExitKind,
+	StackState, StackSubstateMetadata,
 };
 
 pub use self::memory::{MemoryStackAccount, MemoryStackState, MemoryStackSubstate};


### PR DESCRIPTION
Minor extensions. Also, Drop impl for both Resolve types has been removed since it made runtime unusable just after trap (it overwrote stack pointer). 