### PR TITLE
Zil 5269 add support for reading init data by scilla read precompile

### DIFF
--- a/core/src/opcode.rs
+++ b/core/src/opcode.rs
@@ -273,7 +273,7 @@ impl Opcode {
 }
 
 impl fmt::Display for Opcode {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		//write!(f, "{}", "urgh...")
 		let op = match self {
 			&Opcode::STOP => "STOP",
@@ -423,6 +423,5 @@ impl fmt::Display for Opcode {
 			_ => "UNKNOWNOP",
 		};
 		write!(f, "{}", op)
-	  }
+	}
 }
-

--- a/src/backend/memory.rs
+++ b/src/backend/memory.rs
@@ -146,6 +146,10 @@ impl<'vicinity> Backend for MemoryBackend<'vicinity> {
 		self.code(address)
 	}
 
+	fn init_data_as_json(&self, _address: H160) -> Vec<u8> {
+		Vec::new()
+	}
+
 	fn storage(&self, address: H160, index: H256) -> H256 {
 		self.state
 			.get(&address)

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -81,6 +81,8 @@ pub trait Backend {
 	fn code(&self, address: H160) -> Vec<u8>;
 	/// Get account code formatted as json (if possible)
 	fn code_as_json(&self, address: H160) -> Vec<u8>;
+	/// Get contract init data formatted as json (if possible)
+	fn init_data_as_json(&self, address: H160) -> Vec<u8>;
 	/// Get storage value of address at inasex.
 	fn storage(&self, address: H160, index: H256) -> H256;
 	/// Get original storage value of address at index, if available.

--- a/src/executor/stack/memory.rs
+++ b/src/executor/stack/memory.rs
@@ -481,6 +481,10 @@ impl<'backend, 'config, B: Backend> Backend for MemoryStackState<'backend, 'conf
 		self.backend.code_as_json(address)
 	}
 
+	fn init_data_as_json(&self, address: H160) -> Vec<u8> {
+		self.backend.init_data_as_json(address)
+	}
+
 	fn storage(&self, address: H160, key: H256) -> H256 {
 		self.substate
 			.known_storage(address, key)


### PR DESCRIPTION
Allows evm to read contract init data via backend.